### PR TITLE
Support for variable refresh rate

### DIFF
--- a/source/abstract.py
+++ b/source/abstract.py
@@ -21,6 +21,7 @@ class AbstractSource(abc.ABC):
         self.number_of_pixels = self.height * self.width
         self._buffer = np.zeros((self.height, self.width, 3), dtype=np.uint8)
         self.totalTime = 0.
+        self.fps = 0
         self._type = SourceType.base
     
     @property

--- a/source/animation.py
+++ b/source/animation.py
@@ -43,7 +43,7 @@ class AnimationSource(AbstractSource):
 
             try:
                 # The time to display the current frame of the GIF, in milliseconds and store
-                self.duration.append(float(im.info["duration"]) / 1000)
+                self.duration.append(float(im.info["duration"]))
                 im.seek(im.tell() + 1)
             except KeyError:
                 print("{} has no duration meta data!".format(filename))

--- a/source/image.py
+++ b/source/image.py
@@ -12,6 +12,7 @@ class ImageSource(AbstractSource):
         super().__init__(width, height)
         self._type = SourceType.image
         self.load(filename)
+        self.fps = 1
 
     def load(self, filename):
         im = Image.open(filename)


### PR DESCRIPTION
PyGame clock used to run the game loop
- Previous FPS limiter was not functioning properly (FPS varied).
- New clock allows to easily change the FPS on the fly.

Source can flag which FPS the buffer should be displayed at
- Images set to 1 FPS
- Videos read from the meta data (usually 25-30 FPS)
- Animation calculates the time as usual